### PR TITLE
Feature/modify weight flow

### DIFF
--- a/main/app_weight.c
+++ b/main/app_weight.c
@@ -241,8 +241,11 @@ static void weight_fsm_check_jump(void) {
         ++task_data.jump_cnt;
 
         if ((w_task_cb.now_weight_g - w_task_cb.ref_weight_g) <
-                (0.5 * w_task_cb.conf.jump_cat_weight_g) &&
-            !w_task_cb.pir_level) {
+                (0.5 * w_task_cb.conf.jump_cat_weight_g)
+#if (FUNC_WEIGHT_JUMP_CHECK_PIR)
+            && !w_task_cb.pir_level
+#endif
+        ) {
             task_data.jump_to_bigjump_cnt = 0;
             ++task_data.jump_to_standby_cnt;
             ESP_LOGI(TAG, "jump_to_standby_cnt: %d",
@@ -250,8 +253,11 @@ static void weight_fsm_check_jump(void) {
             if (task_data.jump_to_standby_cnt == task_data.jump_to_standby_num)
                 weight_fsm_goto_standby();
         } else if ((w_task_cb.now_weight_g - w_task_cb.ref_weight_g) >=
-                       (0.5 * w_task_cb.conf.jump_cat_weight_g) &&
-                   w_task_cb.pir_level) {
+                       (0.5 * w_task_cb.conf.jump_cat_weight_g)
+#if (FUNC_WEIGHT_JUMP_CHECK_PIR)
+                   && w_task_cb.pir_level
+#endif
+        ) {
             task_data.jump_to_standby_cnt = 0;
             ++task_data.jump_to_bigjump_cnt;
             ESP_LOGI(TAG, "jump_to_bigjump_cnt: %d",

--- a/main/app_weight.c
+++ b/main/app_weight.c
@@ -219,8 +219,6 @@ static void weight_fsm_check_standby(void) {
 
 static void weight_fsm_goto_standby(void) {
     // action
-    board_led_ctrl(LED_TYPE_BD_W, false); // turn off W led
-    board_led_ctrl(LED_TYPE_IR, false);   // turn off IR led
     task_data.weight_pause_times = 0;
     task_data.period_ms = w_task_cb.conf.standby_period_ms;
     task_data.ref_adc_exec = true;
@@ -300,7 +298,6 @@ static void weight_fsm_check_bigjump(void) {
 
 static void weight_fsm_goto_bigjump(void) {
     // action
-    board_led_ctrl(LED_TYPE_IR, true); // turn on IR led
     task_data.period_ms = w_task_cb.conf.bigjump_period_ms;
     task_data.period_cnt = 0;
     weight_post_event(task_data.evt_loop, w_task_cb.now_weight_g,
@@ -331,7 +328,6 @@ static void weight_fsm_check_postevent(void) {
 
 static void weight_fsm_goto_postevent(void) {
     // action
-    board_led_ctrl(LED_TYPE_BD_W, true); // turn on W led
     task_data.postevnet_num = w_task_cb.conf.postevnet_chk;
     task_data.postevnet_cnt = 0;
     task_data.period_ms = w_task_cb.conf.postevent_period_ms;

--- a/main/board_driver.c
+++ b/main/board_driver.c
@@ -62,7 +62,7 @@ static esp_err_t board_cam_init(void);
 static esp_err_t board_ioe_output_en(uint8_t port, uint8_t pin,
                                      gpio_output_level_e level) {
     uint8_t port_addr;
-    uint8_t latch_addr;
+    // uint8_t latch_addr;
     uint8_t port_val;
     // uint8_t latch_val;
     esp_err_t esp_err;

--- a/main/board_driver.c
+++ b/main/board_driver.c
@@ -765,7 +765,7 @@ bool board_get_key_status(void) {
 
     if (i2c_MCP23016_readREG(I2C_MASTER_NUM, MCP23016_GPIO1_ADDR, &port_val) !=
         ESP_OK) {
-        ESP_LOGE(TAG, "MCP23016 read failed port_val[0x%02x]", port_val);
+        ESP_LOGD(TAG, "MCP23016 read failed port_val[0x%02x]", port_val);
         return false;
     }
 

--- a/main/include/app_weight.h
+++ b/main/include/app_weight.h
@@ -59,6 +59,7 @@ typedef struct {
 typedef struct {
     rawdata_eventid eventid;
     int weight_g;
+    int ref_weight_g;
     int pir_val;
 } weight_take_photo_event_t;
 

--- a/main/include/util.h
+++ b/main/include/util.h
@@ -40,7 +40,7 @@ extern "C" {
 #define CAMERA_FRAME_SIZE FRAMESIZE_XGA
 
 #define ESP_INTR_FLAG_DEFAULT 0
-#define CAM_RING_BUF_SIZE 4
+#define CAM_RING_BUF_SIZE 2
 
 #if CONFIG_CAMERA_MODEL_WROVER_KIT
 #define PWDN_GPIO_NUM -1
@@ -240,6 +240,9 @@ extern "C" {
 #define FUNC_KEY_EVENT 0
 #define FUNC_WEIGHT_JUMP_CHECK_PIR                                             \
     0 // weight_fsm_check_jump 0:without/1:with PIR
+#define FUNC_WEIGHT_BIGJUMP_SEND_PHOTO_PERIOD_MS 3000
+
+#define FUNC_TAKE_PHOTO_DELAY_MS 300
 
 // Testing firmware default value
 #if 1

--- a/main/include/util.h
+++ b/main/include/util.h
@@ -238,6 +238,8 @@ extern "C" {
     0 // 1: nvs will be earesd during bootup for debugging blufi process
 #define FUNC_PHOTO_RINGBUFFER 1 // 1: photo will be saved when wifi dosconnected
 #define FUNC_KEY_EVENT 0
+#define FUNC_WEIGHT_JUMP_CHECK_PIR                                             \
+    0 // weight_fsm_check_jump 0:without/1:with PIR
 
 // Testing firmware default value
 #if 1

--- a/main/include/util.h
+++ b/main/include/util.h
@@ -10,7 +10,7 @@ extern "C" {
 // Version
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 0
-#define VERSION_PATCH 4
+#define VERSION_PATCH 5
 
 // bitwise
 #ifndef BIT

--- a/main/task_httpc.c
+++ b/main/task_httpc.c
@@ -85,6 +85,8 @@ static bool http_photo_buf_get_loop_ram(void);
 static uint8_t http_photo_buf_get_idx_ram(void);
 static bool http_photo_buf_exist_ram(void);
 static void http_photo_buf_init(void);
+static esp_err_t take_photo(camera_fb_t **fb, rawdata_eventid event,
+                            uint32_t delay_ms);
 
 static void httpc_task(void *pvParameter);
 
@@ -836,6 +838,58 @@ static void http_photo_buf_init(void) {
     photo_ring_buf.loop = false;
 }
 
+static esp_err_t take_photo(camera_fb_t **fb, rawdata_eventid event,
+                            uint32_t delay_ms) {
+    switch (event) {
+    case RAWDATA_EVENTID_TEST:
+    case RAWDATA_EVENTID_CAT_OUT:
+        board_led_ctrl(LED_TYPE_BD_W, true); // turn on W led
+        board_led_ctrl(LED_TYPE_IR, true);   // turn on IR led
+        break;
+
+    case RAWDATA_EVENTID_CAT_IN:
+        board_led_ctrl(LED_TYPE_IR, true); // turn on IR led
+        break;
+
+    default:
+        ESP_LOGE(TAG, "not support event[%d] L%d", event, __LINE__);
+        break;
+    }
+
+    for (int d_idx = 0; d_idx < CAM_RING_BUF_SIZE; ++d_idx) {
+        camera_fb_t *fb = esp_camera_fb_get();
+        esp_camera_fb_return(fb);
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(delay_ms));
+    esp_err_t esp_err;
+
+    esp_err = camera_take_photo(fb);
+    if (esp_err != ESP_OK) {
+        ESP_LOGE(TAG, "err: %s[%d] L%d", esp_err_to_name(esp_err), esp_err,
+                 __LINE__);
+        return esp_err;
+    }
+
+    switch (event) {
+    case RAWDATA_EVENTID_TEST:
+    case RAWDATA_EVENTID_CAT_OUT:
+        board_led_ctrl(LED_TYPE_BD_W, false); // turn off W led
+        board_led_ctrl(LED_TYPE_IR, false);   // turn off IR led
+        break;
+
+    case RAWDATA_EVENTID_CAT_IN:
+        board_led_ctrl(LED_TYPE_IR, false); // turn off IR led
+        break;
+
+    default:
+        ESP_LOGE(TAG, "not support event[%d] L%d", event, __LINE__);
+        break;
+    }
+
+    return esp_err;
+}
+
 static bool http_photo_buf_exist_fs(void) { return fs_check_photo_cfg_exist(); }
 
 static void save_timeval_into_nvs(void) {
@@ -1070,12 +1124,11 @@ void http_photo_buf_push_ram(weight_take_photo_event_t *take_photo_event) {
 
     memcpy(&photo_buf->weight_take_photo_evt, take_photo_event,
            sizeof(weight_take_photo_event_t));
+
     photo_buf->unix_timestamp = time(NULL);
-    esp_err_t esp_err = camera_take_photo(&photo_buf->fb);
-    if (esp_err != ESP_OK) {
-#if (FUNC_TESTING_FW)
-        printf("err: take photo failed");
-#endif
+
+    if (take_photo(&photo_buf->fb, take_photo_event->eventid,
+                   FUNC_TAKE_PHOTO_DELAY_MS) != ESP_OK) {
         return;
     }
 
@@ -1083,9 +1136,6 @@ void http_photo_buf_push_ram(weight_take_photo_event_t *take_photo_event) {
         ESP_LOGE(TAG, "camera use the %d format",
                  photo_buf->fb->format); // TODO: record into fetal error nvs
         esp_camera_fb_return(photo_buf->fb);
-#if (FUNC_TESTING_FW)
-        printf("err: photo format failed");
-#endif
         return;
     }
 
@@ -1105,7 +1155,11 @@ void http_photo_buf_push_fs(weight_take_photo_event_t *take_photo_event) {
     ESP_LOGI(TAG, "%s start", __func__);
     ESP_LOGI(TAG, "sizeof(camera_fb_t): %d", sizeof(camera_fb_t));
     unix_timestamp = time(NULL);
-    camera_take_photo(&fb);
+
+    if (take_photo(&fb, take_photo_event->eventid, FUNC_TAKE_PHOTO_DELAY_MS) !=
+        ESP_OK) {
+        return;
+    }
     if (fb->format != PIXFORMAT_JPEG) {
         ESP_LOGE(TAG, "camera use the %d format",
                  fb->format); // TODO: record into fetal error nvs
@@ -1162,6 +1216,7 @@ void http_send_photo_process(httpc_photo_source_e photo_src) {
                     photo_buf_ram = http_photo_buf_pop_ram(i);
                     http_send_photo_buf(photo_buf_ram, client, json_url_val,
                                         JSON_URL_VAL_LEN);
+                    camera_return_photo(&photo_buf_ram->fb);
                 }
             }
             for (int i = 0; i < buf_start_idx; ++i) {
@@ -1169,6 +1224,7 @@ void http_send_photo_process(httpc_photo_source_e photo_src) {
                 photo_buf_ram = http_photo_buf_pop_ram(i);
                 http_send_photo_buf(photo_buf_ram, client, json_url_val,
                                     JSON_URL_VAL_LEN);
+                camera_return_photo(&photo_buf_ram->fb);
             }
         }
     }


### PR DESCRIPTION
### v1.0.5
1. fix: camera can not get the latest photo
2. feat: move white and IR led on/off logic into task_http
3. fix: event_id == 1 to reply cat's weight
4. feat: add reference weight parameter into http_post_rawdata
5. feat: send photos into backend every 3 seconds during weight_fsm_check_bigjump
6. feat: remove annoying error message of io-expander
